### PR TITLE
Unit test fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,18 @@
 {
   "configurations": [
     {
+      "name": "Hosted Unit Test Debug",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceRoot}/test/build/bin/tests",
+      "args": [],
+      "stopAtEntry": true,
+      "cwd": "${workspaceRoot}/test/build/bin",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb"
+    },
+    {
       "name": "On Device Debug",
       "configFiles": [
           "interface/stlink.cfg",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-#
-#   some of the included cmake files depend on TARGET being defined
-#
 set(TARGET daisyvscodetemplate)
 
 set(SOURCES
@@ -18,12 +15,16 @@ foreach(SRC_FILE ${SOURCES})
 endforeach()
 
 # Link libraries
-target_link_libraries(${TARGET} ${DAISYSP_DIR}/build/libdaisysp.a)
-target_link_libraries(${TARGET} ${LIBDAISY_DIR}/build/libdaisy.a)
+target_link_libraries(${TARGET} PRIVATE
+    ${DAISYSP_DIR}/build/libdaisysp.a
+    ${LIBDAISY_DIR}/build/libdaisy.a
+    #${DAISYSP_DIR}/DaisySP-LGPL/build/libdaisysp-lgpl.a
+)
 
 # Include directories
 target_include_directories(${TARGET} PRIVATE
     ${DAISYSP_DIR}/Source
+    #${DAISYSP_DIR}/DaisySP-LGPL/Source
     ${LIBDAISY_DIR}/src/
     ${LIBDAISY_DIR}/src/sys
     ${LIBDAISY_DIR}/src/usbh

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,5 +23,7 @@ set_target_properties(tests PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
 )
 
+target_compile_options(tests PRIVATE -g)
+
 add_test(NAME tests COMMAND tests)
 enable_testing()


### PR DESCRIPTION
Added unit-test debug config to launch.json. Use compiler flag -g when building unit tests