### PR TITLE
fix: resolve critical template issues and improve consistency

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,7 +1,7 @@
 {
     "env": {
-        "DAISYSP_DIR": "${workspaceFolder}/daisysp",
-        "LIBDAISY_DIR": "${workspaceFolder}/libdaisy"
+        "DAISYSP_DIR": "${workspaceFolder}/thirdparty/DaisySP",
+        "LIBDAISY_DIR": "${workspaceFolder}/thirdparty/libDaisy"
     },
     "configurations": [
         {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 set(LIBDAISY_DIR ${CMAKE_SOURCE_DIR}/thirdparty/libDaisy)
 set(DAISYSP_DIR ${CMAKE_SOURCE_DIR}/thirdparty/DaisySP)
 
-project(DaisyVSCodeTemplate VERSION 0.1.0 LANGUAGES CXX)
+project(daisyseed-vscode-template VERSION 0.1.0 LANGUAGES CXX)
 
 #
-# Where shuld this progeam be installed and run from? Possible values are:
+# Where should this program be installed and run from? Possible values are:
 # BOOT_FLASH, BOOT_SRAM, BOOT_QSPI
 #
 # Both BOOT_SRAM and BOOT_QSPI require the Daisy bootloader to be installed.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ My [deepnote-seed](https://github.com/davidirvine/deepnote-seed) project is an e
 To create a private repo using this repo as a template:
 
 ```
-gh repo create {new_repo_name} --private --clone --template davidirvine/DaisyVSCodeTemplate
+gh repo create {new_repo_name} --private --clone --template davidirvine/daisyseed-vscode-template
 ```
 
 ## Values You'll Want to Change
 
-When creating a nekw project from this template you'll need to change the following values:
+When creating a new project from this template you'll need to change the following values:
 
 - `CMakeLists.txt:16` project name
 - `src/CMakeLists.txt:4` TARGET value
@@ -67,7 +67,7 @@ make program-ocd
 ```
 
 ## Unit Tests
-The `test` directory is there to support compiling and running unit tests on the host platdform using [DocTest](https://github.com/doctest/doctest). Of course you can only test code that has no dependencies on hardware. A version of DocTest can be found in the `thirdparty` directory.
+The `test` directory is there to support compiling and running unit tests on the host platform using [DocTest](https://github.com/doctest/doctest). Of course you can only test code that has no dependencies on hardware. A version of DocTest can be found in the `thirdparty` directory.
 
 After you add your test sources and dependencies to `test/CMakeLists.txt` you'll want to set up you unit test build with:
 ```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.10)
 project(test)
 
 
@@ -7,12 +7,12 @@ include_directories(
     ../thirdparty
 )
 
-set(TESTS_SOUCES
+set(TESTS_SOURCES
     main.cpp
 )
 
 add_executable(tests 
-  ${TESTS_SOUCES}
+  ${TESTS_SOURCES}
 )
 
 set_target_properties(tests PROPERTIES
@@ -20,7 +20,7 @@ set_target_properties(tests PROPERTIES
   CXX_STANDARD_REQUIRED YES
   C_STANDARD 11
   C_STANDARD_REQUIRED YES
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
 target_compile_options(tests PRIVATE -g)


### PR DESCRIPTION
- Fix typos in README.md ("nekw" → "new", "platdform" → "platform")
- Correct project name from "DaisyVSCodeTemplate" to "daisyseed-vscode-template"
- Fix CMake variable typo (TESTS_SOUCES → TESTS_SOURCES) in test configuration
- Standardize CMake minimum version requirement to 3.10 across all files
- Correct VSCode IntelliSense paths to use proper thirdparty directory structure
- Fix spelling errors in CMakeLists.txt comments ("shuld progeam" → "should program")
- Update template repository references in documentation
- Improve test executable output directory structure
- Add missing newlines at end of files

These changes address naming inconsistencies, configuration errors, and documentation issues that would cause confusion for new users of the template. The fixes ensure the template works correctly out-of-the-box and follows consistent naming conventions throughout all configuration files.